### PR TITLE
Added type hint fix compile error in TypeScript 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 XHR (Ajax) Wrapper for XMLHttpRequest. Supports promise-based returns, similar to fetch.
 
 ## Changelog
+* February 7th, 2019 - Updated type to be compatible with TypeScript version 3.
 * May 8th, 2017 - Updated content-type for `PUT` request type.
 * April 20th, 2017 - Updated library to allow for `FormData` and file uploads.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-xhr",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "XHR (Ajax) Wrapper for XMLHttpRequest. Supports promise-based returns, similar to fetch.",
   "main": "dist/ajax.js",
   "scripts": {
@@ -25,6 +25,6 @@
   "homepage": "https://github.com/gtmsportswear/js-xhr#readme",
   "devDependencies": {
     "tslint": "^5.1.0",
-    "typescript": "^2.2.2"
+    "typescript": "^3.2.2"
   }
 }

--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -42,7 +42,7 @@ export const ajax: AjaxRequest = (req: AjaxRequestObject): Promise<any> => {
 
     httpRequest.open(req.type, req.url);
 
-    let data = req.data;
+    let data = <string>req.data;
     if (!FormData.prototype.isPrototypeOf(req.data)) {
       data = convertToEncodedForm(req.data);
       setContentTypeHeader(httpRequest, req.type);


### PR DESCRIPTION
Needing to update this package after 2 years to keep it compatible with Typescript 3.